### PR TITLE
閉じ括弧補完処理の ) を > に修正

### DIFF
--- a/_vimrc
+++ b/_vimrc
@@ -63,7 +63,7 @@ let g:ruby_refactoring_map_keys=1
 inoremap ( ()<ESC>i
 inoremap <expr> ) ClosePair(')')
 inoremap < <><ESC>i
-inoremap <expr> ) ClosePair('>')
+inoremap <expr> > ClosePair('>')
 inoremap { {}<ESC>i
 inoremap <expr> } ClosePair('}')
 inoremap [ []<ESC>i


### PR DESCRIPTION
66 行目において，恐らく > と書くべきところが ) になっていましたので修正しました．

修正前の状態では閉じ括弧 ) だけを入力することが不可能でした．
